### PR TITLE
Use HTTP_X_FORWARDED_HOST if it is set to generate base_url

### DIFF
--- a/lib/schnitzelpress/helpers.rb
+++ b/lib/schnitzelpress/helpers.rb
@@ -9,7 +9,7 @@ module Schnitzelpress
     end
 
     def base_url
-      "#{env['rack.url_scheme']}://#{env['HTTP_HOST']}/"
+      "#{env['rack.url_scheme']}://#{env['HTTP_X_FORWARDED_HOST']||env['HTTP_HOST']}/"
     end
 
     def partial(thing, locals = {})


### PR DESCRIPTION
This makes schnitzelpress output correct base_urls if it is run in a reverse proxy setup.
